### PR TITLE
Rename media conversion from 'feature_image' to 'post_feature_image' for better clarity and consistency in the codebase.

### DIFF
--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -35,7 +35,7 @@ class Page extends Model implements HasMedia
 
     public function registerMediaConversions(?Media $media = null): void
     {
-        $this->addMediaConversion('post_feature_image')
+        $this->addMediaConversion('page_feature_image')
             ->withResponsiveImages()
             ->performOnCollections('page_feature_image');
     }

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -35,7 +35,7 @@ class Page extends Model implements HasMedia
 
     public function registerMediaConversions(?Media $media = null): void
     {
-        $this->addMediaConversion('feature_image')
+        $this->addMediaConversion('post_feature_image')
             ->withResponsiveImages()
             ->performOnCollections('page_feature_image');
     }


### PR DESCRIPTION
### Summary of Changes

This pull request renames the media conversion identifier from `'feature_image'` to `'page_feature_image'` to enhance clarity and consistency within the codebase.

### Changes
- In `src/Models/Page.php`, the media conversion method `addMediaConversion` is updated to use `'page_feature_image'` instead of `'feature_image'`.